### PR TITLE
Merge Projects Now Includes ShapeFiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,7 @@
         "PYTHONPATH": "${workspaceFolder}"
       },      
       "args": [
+        "production", // staging
         "{env:DATA_ROOT}/merge-projects",
       ]
     },

--- a/scripts/geo/merge-projects.py
+++ b/scripts/geo/merge-projects.py
@@ -66,8 +66,8 @@ def merge_projects(projects_lookup: Dict[str, RiverscapesProject], merged_dir: s
             continue
         first_project_xml = project_xml
 
-        # get_raster_datasets(project_xml, project_rasters, regex_list)
-        # get_geopackage_datasets(project_xml, project_vectors, regex_list)
+        get_raster_datasets(project_xml, project_rasters, regex_list)
+        get_geopackage_datasets(project_xml, geopkge_vectors, regex_list)
         get_shapefile_datasets(project_xml, shpfile_vectors, regex_list)
         get_bounds_geojson_file(project_xml, bounds_geojson_files)
 

--- a/scripts/geo/merge-projects.py
+++ b/scripts/geo/merge-projects.py
@@ -430,12 +430,13 @@ def main():
     """
 
     parser = argparse.ArgumentParser()
+    parser.add_argument('environment', help='production or staging', type=str)
     parser.add_argument('working_folder', help='top level folder for downloads and output', type=str)
     args = dotenv.parse_args_env(parser)
 
     default_file_regex = r'.*'
 
-    with RiverscapesAPI() as api:
+    with RiverscapesAPI(args.environment) as api:
         project_types = api.get_project_types()
         questions = [
             inquirer.Text('collection_id', message="Enter a valid Collection ID"),


### PR DESCRIPTION
This enhances the merge project script to also include ShapeFiles. Previously it only worked on rasters and GeoPackages. 

This means we now get roads, rail, ecoregions, counties and states (plus probably some others) in our merge projects.

I tried to repurpose the code that does GeoPackages to also do ShapeFiles, but the dimensionality was too different. (i.e. GeoPackages can have many layers, whereas ShapeFiles just have the one layer). It was also less risky to leave the existing code alone and write new methods dedicated to ShapeFiles.